### PR TITLE
NetSpeedStatusIcon: align to CENTER for consistency

### DIFF
--- a/net_speed_status_icon.js
+++ b/net_speed_status_icon.js
@@ -20,6 +20,7 @@ const Gettext = imports.gettext;
 const Lang = imports.lang;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
+const Clutter = imports.gi.Clutter;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 
@@ -46,12 +47,12 @@ const NetSpeedStatusIcon = new Lang.Class({
 	this._icon = this._get_icon(this._net_speed.get_device_type(this._net_speed.device));
 	this._upicon = this._get_icon("up");
 	this._downicon = this._get_icon("down");
-	this._sum = new St.Label({ text: "---", style_class: 'ns-label'});
-	this._sumunit = new St.Label({ text: "", style_class: 'ns-unit-label'});
-	this._up = new St.Label({ text: "---", style_class: 'ns-label'});
-	this._upunit = new St.Label({ text: "", style_class: 'ns-unit-label'});
-	this._down = new St.Label({ text: "---", style_class: 'ns-label'});
-	this._downunit = new St.Label({ text: "", style_class: 'ns-unit-label'});
+	this._sum = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
+	this._sumunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
+	this._up = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
+	this._upunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
+	this._down = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
+	this._downunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
 
 	this._box.add_actor(this._sum);
 	this._box.add_actor(this._sumunit);

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -5,7 +5,7 @@
 
 .ns-unit-label {
 	font-size: 65%;
-	padding: 5px 2px 0px 0px;
+	padding: 3px 2px 0px 0px;
 }
 
 .ns-menuitem {


### PR DESCRIPTION
This will cause the panel menu labels to all be aligned at the same
height as other elements (such as the date, and "Activities").
