### PR TITLE
Remove redeclaration of `up` and `down` (Fix for GNOME 3.24)

### DIFF
--- a/net_speed.js
+++ b/net_speed.js
@@ -201,8 +201,6 @@ const NetSpeed = new Lang.Class(
         }
 
         var total = 0;
-        var up = 0;
-        var down = 0;
         var total_speed = null;
         var up_speed = null;
         var down_speed = null;


### PR DESCRIPTION
This fixes the extension in GNOME 3.24