### PR TITLE
Fix "TypeError: redeclaration of let up" error on new GJS

### DIFF
--- a/net_speed.js
+++ b/net_speed.js
@@ -177,8 +177,6 @@ const NetSpeed = new Lang.Class(
         let flines = GLib.file_get_contents('/proc/net/dev'); // Read the file
         let nlines = ("" + flines[1]).split("\n"); // Break to lines
 
-        let up = 0; // set initial
-        let down = 0;
         this._oldvalues = this._values;
         this._values = new Array();
         this._speeds = new Array();
@@ -200,12 +198,12 @@ const NetSpeed = new Lang.Class(
             this._devices.push(params[0].replace(":",""));
         }
 
-        var total = 0;
-        var up = 0;
-        var down = 0;
-        var total_speed = null;
-        var up_speed = null;
-        var down_speed = null;
+        let total = 0;
+        let up = 0;
+        let down = 0;
+        let total_speed = null;
+        let up_speed = null;
+        let down_speed = null;
         if (this._check_devices() == 1)	{
             for (let i = 0; i < this._values.length; ++i) {
                 let _up = this._values[i][0] - this._oldvalues[i][0];


### PR DESCRIPTION
```
JS ERROR: Exception in callback for signal: extension-found: TypeError: redeclaration of let up
@/home/zh/.local/share/gnome-shell/extensions/netspeed@hedayaty.gmail.com/extension.js:19:7
initExtension@resource:///org/gnome/shell/ui/extensionSystem.js:221:5
loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:168:18
_loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:304:9
_emit@resource:///org/gnome/gjs/modules/signals.js:126:27
ExtensionFinder<._loadExtension@resource:///org/gnome/shell/misc/extensionUtils.js:184:9
wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
bind/<@resource:///org/gnome/gjs/modules/lang.js:95:16
collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:1
ExtensionFinder<.scanExtensions@resource:///org/gnome/shell/misc/extensionUtils.js:189:9
wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
_loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:306:5
enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:314:9
_sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:345:9
init@resource:///org/gnome/shell/ui/extensionSystem.js:353:5
_initializeUI@resource:///org/gnome/shell/ui/main.js:219:5
start@resource:///org/gnome/shell/ui/main.js:127:5
@<main>:1:31
```