### PR TITLE
Fixes bug in Gnome 3.24

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,8 @@
   "description": "Displays Internet Speed",
   "name": "NetSpeed",
   "original-author": "hedayaty@gmail.com",
-  "shell-version": [ "3.10" , "3.12", "3.14", "3.16", "3.18" ],
+  "shell-version": [ "3.10" , "3.12", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24" ],
   "url": "https://github.com/hedayaty/NetSpeed",
   "uuid": "netspeed@hedayaty.gmail.com",
-  "version": 25
+  "version": 26
 }

--- a/net_speed.js
+++ b/net_speed.js
@@ -201,8 +201,8 @@ const NetSpeed = new Lang.Class(
         }
 
         var total = 0;
-        var up = 0;
-        var down = 0;
+        up = 0;
+        down = 0;
         var total_speed = null;
         var up_speed = null;
         var down_speed = null;


### PR DESCRIPTION
Variables "up"/"down" were defined twice which lead to a TypeError starting from Gnome 3.24 on. Fixed it by just removing the 2nd 'var'.

Additionally added new gnome versoins to the metadata to make them understood (using it since 3.18, so it acutally really works on this versions inbetween).