### PR TITLE
extension: make compatible with libnm

### DIFF
--- a/net_speed.js
+++ b/net_speed.js
@@ -15,6 +15,10 @@
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
 
+/* Ugly. This is here so that we don't crash old libnm-glib based shells unnecessarily
+ * by loading the new libnm.so. Should go away eventually */
+const libnm_glib = imports.gi.GIRepository.Repository.get_default().is_registered("NMClient", "1.0");
+
 const Lang = imports.lang;
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const Gettext = imports.gettext;
@@ -24,8 +28,8 @@ const GLib = imports.gi.GLib;
 const Mainloop = imports.mainloop;
 const Panel = imports.ui.main.panel;
 
-const NMC = imports.gi.NMClient;
-const NetworkManager = imports.gi.NetworkManager;
+const NMC = libnm_glib ? imports.gi.NMClient : imports.gi.NM;
+const NetworkManager = libnm_glib ? imports.gi.NetworkManager : NMC;
 
 const _ = Gettext.domain('netspeed').gettext;
 const NetSpeedStatusIcon = Extension.imports.net_speed_status_icon;
@@ -298,7 +302,7 @@ const NetSpeed = new Lang.Class(
 
         this._values = new Array();
         this._devices = new Array();
-        this._client = NMC.Client.new();
+        this._client = libnm_glib ? NMC.Client.new() : NMC.Client.new(null);
 
         let schemaDir = Extension.dir.get_child('schemas').get_path();
         let schemaSource = Gio.SettingsSchemaSource.new_from_directory(

--- a/prefs.js
+++ b/prefs.js
@@ -15,6 +15,10 @@
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
 
+/* Ugly. This is here so that we don't crash old libnm-glib based shells unnecessarily
+ * by loading the new libnm.so. Should go away eventually */
+const libnm_glib = imports.gi.GIRepository.Repository.get_default().is_registered("NMClient", "1.0");
+
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
@@ -23,8 +27,8 @@ const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
-const NMC = imports.gi.NMClient;
-const NetworkManager = imports.gi.NetworkManager;
+const NMC = libnm_glib ? imports.gi.NMClient : imports.gi.NM;
+const NM = libnm_glib ? imports.gi.NetworkManager : NMC;
 const _ = Gettext.domain('netspeed').gettext;
 
 let schemaDir = Extension.dir.get_child('schemas').get_path();
@@ -59,28 +63,28 @@ const App = new Lang.Class(
         listStore.set (defaultGw, [0], [_("Default Gateway")]);
         listStore.set (defaultGw, [1], ["gtk-network"]);
 
-        let nmc = NMC.Client.new();
+        let nmc = libnm_glib ? NMC.Client.new() : NMC.Client.new(null);
         this._devices = nmc.get_devices() || [ ];
 
         for each (let dev in this._devices) {
             let iconname;
             switch (dev.device_type) {
-                case NetworkManager.DeviceType.ETHERNET:
+                case NM.DeviceType.ETHERNET:
                     iconname = "network-wired-symbolic";
                     break;
-                case NetworkManager.DeviceType.WIFI:
+                case NM.DeviceType.WIFI:
                     iconname = "network-wireless-signal-excellent-symbolic";
                     break;
-                case NetworkManager.DeviceType.BT:
+                case NM.DeviceType.BT:
                     iconname = "bluetooth-active-symbolic";
                     break;
-                case NetworkManager.DeviceType.OLPC_MESH:
+                case NM.DeviceType.OLPC_MESH:
                     iconname = "network-wired-symbolic";
                     break;
-                case NetworkManager.DeviceType.WIMAX:
+                case NM.DeviceType.WIMAX:
                     iconname = "network-wirelss-signal-excellent-symbolic"; // Same for wifi
                     break;
-                case NetworkManager.DeviceType.MODEM:
+                case NM.DeviceType.MODEM:
                     iconname = "gnome-transmit-symbolic";
                     break;
                 default:


### PR DESCRIPTION
libnm-glib has been deprecated in favor of libnm for ages. GNOME Shell
seems to be among the last bits to be ported. This is now being done [1]:

[1] https://bugzilla.gnome.org/show_bug.cgi?id=789811

Unfortunately, due to GLib limitations, libnm-glib.so and libnm.so can't
be loaded at the same time and the attempt to do so results in a nasty
crash. The extensions thus needs to be updated to libnm.