### PR TITLE
Port to GNOME Shell 3.32.

### DIFF
--- a/layout_menu_item.js
+++ b/layout_menu_item.js
@@ -15,25 +15,21 @@
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
 
-const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 
 /**
  * Class: LayoutMenuItem
  */
-const LayoutMenuItem = new Lang.Class(
+const LayoutMenuItem = class LayoutMenuItem extends PopupMenu.PopupBaseMenuItem
 {
-    Name: 'LayoutMenuItem',
-    Extends: PopupMenu.PopupBaseMenuItem,
-
     /**
      * LayoutMenuItem: _init
      * Constructor
      */
-    _init: function(device, icon, menu_label_size)
+    constructor(device, icon, menu_label_size)
     {
-        this.parent();
+        super();
         this.device = device;
         this._icon = icon;
         this._device_title = new St.Label(
@@ -52,26 +48,26 @@ const LayoutMenuItem = new Lang.Class(
         this.actor.add(this._down_label);
         this.actor.add(this._up_label);
         this.update_ui(menu_label_size);
-    },
+    }
 
     /**
      * LayoutMenuItem: update_ui
      * update settings
      */
-    update_ui: function(menu_label_size)
+    update_ui(menu_label_size)
     {
         this._down_label.set_width(menu_label_size);
         this._up_label.set_width(menu_label_size);
         this._device_title.set_width(menu_label_size);
-    },
+    }
 
     /**
      * LayoutMenuItem: update_speeds
      * update speeds
      */
-    update_speeds: function(speed)
+    update_speeds(speed)
     {
         this._down_label.set_text(speed.down);
         this._up_label.set_text(speed.up);
-     },
-});
+    }
+};

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Displays Internet Speed",
   "name": "NetSpeed",
   "original-author": "hedayaty@gmail.com",
-  "shell-version": [ "3.10" , "3.12", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26", "3.28" ],
+  "shell-version": [ "3.32" ],
   "url": "https://gitlab.com/hedayaty/NetSpeed",
   "uuid": "netspeed@hedayaty.gmail.com",
   "version": 29

--- a/net_speed.js
+++ b/net_speed.js
@@ -38,28 +38,25 @@ const NetSpeedStatusIcon = Extension.imports.net_speed_status_icon;
  * Class NetSpeed
  * The extension
  */
-const NetSpeed = new Lang.Class(
+const NetSpeed = class NetSpeed
 {
-    Name: 'NetSpeed',
-
     /**
      * NetSpeed: _init
      * Constructor
      */
-    _init : function()
+    constructor()
     {
         let localeDir = Extension.dir.get_child('locale');
         if (localeDir.query_exists(null)) {
             Gettext.bindtextdomain('netspeed', localeDir.get_path());
-		}
+        }
         this._updateDefaultGw();
-    },
+    }
 
     /**
      * NetSpeed: _is_up2date
-
      */
-    _is_up2date: function()
+    _is_up2date()
     {
         if (this._devices.length != this._olddevices.length) {
             return 0;
@@ -69,13 +66,12 @@ const NetSpeed = new Lang.Class(
                 return 0;
         }
         return 1;
-    },
-
+    }
 
     /**
      * NetSpeed: get_device_type
      */
-    get_device_type: function(device)
+    get_device_type(device)
     {
         let devices = this._client.get_devices() || [ ];
 
@@ -101,12 +97,12 @@ const NetSpeed = new Lang.Class(
         }
 
         return "none";
-    },
+    }
 
     /**
      * NetSpeed: _speed_to_string
      */
-    _speed_to_string: function(amount, digits)
+    _speed_to_string(amount, digits)
     {
         if (amount == 0)
             return { text: "0", unit: _("B/s") };
@@ -128,41 +124,40 @@ const NetSpeed = new Lang.Class(
             text: amount.toFixed(digits - 1),
             unit: speed_map[unit]
         };
-    },
-
+    }
 
     /**
      * NetSpeed: _set_labels
      */
-    _set_labels: function(sum, up, down)
+    _set_labels(sum, up, down)
     {
         this._status_icon.set_labels(sum, up, down);
-    },
+    }
 
     /**
      * NetSpeed: _update_speeds
      */
-    _update_speeds: function()
+    _update_speeds()
     {
         this._status_icon.update_speeds(this._speeds);
-    },
+    }
 
     /**
      * NetSpeed: _create_menu
      */
-    _create_menu: function()
+    _create_menu()
     {
         let types = new Array();
         for (let dev of this._devices) {
             types.push(this.get_device_type(dev));
         }
         this._status_icon.create_menu(this._devices, types);
-    },
+    }
 
     /**
      * NetSpeed: _updateDefaultGw
      */
-    _updateDefaultGw : function()
+    _updateDefaultGw()
     {
         let flines = GLib.file_get_contents('/proc/net/route'); // Read the file
         let nlines = ("" + flines[1]).split("\n"); // Break to lines
@@ -176,12 +171,12 @@ const NetSpeed = new Lang.Class(
                 this._defaultGw = params[0];
             }
         }
-    },
+    }
 
     /**
      * NetSpeed: _update
      */
-    _update : function()
+    _update()
     {
         this._updateDefaultGw();
         let flines = GLib.file_get_contents('/proc/net/dev'); // Read the file
@@ -252,13 +247,12 @@ const NetSpeed = new Lang.Class(
         } else
             this._create_menu();
         return true;
-    },
-
+    }
 
     /**
      * NetSpeed: _load
      */
-    _load: function()
+    _load()
     {
         if (this._saving == 1) {
             return;
@@ -271,34 +265,33 @@ const NetSpeed = new Lang.Class(
         this.label_size = this._setting.get_int('label-size');
         this.unit_label_size = this._setting.get_int('unit-label-size');
         this.menu_label_size = this._setting.get_int('menu-label-size');
-    },
+    }
 
     /**
      * NetSpeed: save
      */
-    save: function()
+    save()
     {
         this._saving = 1; // Disable Load
         this._setting.set_boolean('show-sum', this.showsum);
         this._setting.set_string('device', this._device);
         this._saving = 0; // Enable Load
-    },
+    }
 
     /**
      * NetSpeed: _reload
      */
-    _reload: function()
+    _reload()
     {
         this._load();
         this._status_icon.updateui();
-    },
-
+    }
 
     /**
      * NetSpeed: enable
      * exported to enable the extension
      */
-    enable: function()
+    enable()
     {
         this._last_up = 0; // size of upload in previous snapshot
         this._last_down = 0; // size of download in previous snapshot
@@ -321,13 +314,13 @@ const NetSpeed = new Lang.Class(
         this._changed = this._setting.connect('changed', Lang.bind(this, this._reload));
         this._timerid = Mainloop.timeout_add(this.timer, Lang.bind(this, this._update));
         Panel.addToStatusArea('netspeed', this._status_icon, 0);
-    },
+    }
 
     /**
      * NetSpeed: disable
      * exported to disable the extension
      */
-    disable: function()
+    disable()
     {
         if (this._timerid != 0) {
             Mainloop.source_remove(this._timerid);
@@ -340,19 +333,19 @@ const NetSpeed = new Lang.Class(
         this._setting = null;
         this._client = null;
         this._status_icon.destroy();
-    },
+    }
 
-    getDevice: function()
+    getDevice()
     {
         if (this._device == "defaultGW") {
             return this._defaultGw;
         } else {
             return this._device;
         }
-    },
+    }
 
-    setDevice: function(device)
+    setDevice(device)
     {
         this._device = device;
     }
-});
+};

--- a/net_speed_status_icon.js
+++ b/net_speed_status_icon.js
@@ -21,6 +21,7 @@ const Lang = imports.lang;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const Clutter = imports.gi.Clutter;
+const GObject = imports.gi.GObject;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 
@@ -31,29 +32,27 @@ const LayoutMenuItem = Extension.imports.layout_menu_item;
  * Class NetSpeedStatusIcon
  * status icon, texts for speeds, the drodown menu
  */
-const NetSpeedStatusIcon = new Lang.Class(
+const NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends PanelMenu.Button
 {
-    Name: 'NetSpeedStatusIcon',
-    Extends: PanelMenu.Button,
-
     /**
      * NetSpeedStatusIcon: _init
      * Constructor
      */
-    _init: function(net_speed) {
-	    this._net_speed = net_speed;
-	    this.parent(0.0);
-	    this._box = new St.BoxLayout();
-	    this._icon_box = new St.BoxLayout();
+    _init(net_speed)
+    {
+        this._net_speed = net_speed;
+        super._init(0.0);
+        this._box = new St.BoxLayout();
+        this._icon_box = new St.BoxLayout();
         this._icon = this._get_icon(this._net_speed.get_device_type(this._net_speed.getDevice()));
-	    this._upicon = new St.Label({ text: "⬆", style_class: 'ns-icon', y_align: Clutter.ActorAlign.CENTER});
-	    this._downicon = new St.Label({ text: "⬇", style_class: 'ns-icon', y_align: Clutter.ActorAlign.CENTER});
-	    this._sum = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._sumunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._up = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._upunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._down = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._downunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
+        this._upicon = new St.Label({ text: "⬆", style_class: 'ns-icon', y_align: Clutter.ActorAlign.CENTER});
+        this._downicon = new St.Label({ text: "⬇", style_class: 'ns-icon', y_align: Clutter.ActorAlign.CENTER});
+        this._sum = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
+        this._sumunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
+        this._up = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
+        this._upunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
+        this._down = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
+        this._downunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
 
         this._box.add_actor(this._sum);
         this._box.add_actor(this._sumunit);
@@ -91,22 +90,22 @@ const NetSpeedStatusIcon = new Lang.Class(
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         this._layouts = new Array();
         this.updateui();
-    },
+    }
 
     /**
      * NetSpeedStatusIcon :_change_device
      */
-     _change_device : function(param1, param2, device)
+    _change_device(param1, param2, device)
     {
         this._net_speed.setDevice(device);
         this.updateui();
         this._net_speed.save();
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: _toggle_showsum
      */
-    _toggle_showsum : function(actor, event)
+    _toggle_showsum(actor, event)
     {
         let button = event.get_button();
         if (button == 2) { // middle
@@ -114,14 +113,13 @@ const NetSpeedStatusIcon = new Lang.Class(
             this.updateui();
             this._net_speed.save();
         }
-    },
-
+    }
 
     /**
      * NetSpeedStatusIcon: updateui
      * update ui according to settings
      */
-    updateui : function()
+    updateui()
     {
         // Set the size of labels
         this._sum.set_width(this._net_speed.label_size);
@@ -154,8 +152,8 @@ const NetSpeedStatusIcon = new Lang.Class(
 
         // Change the type of Icon
         this._icon.destroy();
-        device = this._net_speed.getDevice();
-	    log("Device -> " + device);
+        const device = this._net_speed.getDevice();
+        log("Device -> " + device);
         this._icon = this._get_icon(this._net_speed.get_device_type(device));
         this._icon_box.add_actor(this._icon);
         // Show icon or not
@@ -167,13 +165,13 @@ const NetSpeedStatusIcon = new Lang.Class(
         for (let layout of this._layouts) {
             layout.update_ui(this._net_speed.menu_label_size);
         }
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: _get_icon
      * Utility function to create icon from name
      */
-    _get_icon: function(name, size)
+    _get_icon(name, size)
     {
         if (arguments.length == 1)
             size = 16;
@@ -217,12 +215,12 @@ const NetSpeedStatusIcon = new Lang.Class(
             icon_name: iconname,
             icon_size: size,
         });
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: set_labels
      */
-    set_labels: function(sum, up, down)
+    set_labels(sum, up, down)
     {
         this._sum.set_text(sum.text);
         this._sumunit.set_text(sum.unit);
@@ -232,16 +230,16 @@ const NetSpeedStatusIcon = new Lang.Class(
 
         this._down.set_text(down.text);
         this._downunit.set_text(down.unit);
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: create_menu
      */
-    create_menu: function(devices, types)
+    create_menu(devices, types)
     {
         for (let layout of this._layouts) {
             layout.destroy();
-         }
+        }
         this._layouts = new Array();
         for (let i = 0; i < devices.length; ++i) {
             let icon = this._get_icon(types[i]);
@@ -250,16 +248,15 @@ const NetSpeedStatusIcon = new Lang.Class(
             this._layouts.push(layout);
             this.menu.addMenuItem(layout);
         }
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: update_speeds
      */
-    update_speeds : function(speeds)
+    update_speeds(speeds)
     {
         for (let i = 0; i < speeds.length; ++i) {
             this._layouts[i].update_speeds(speeds[i]);
         }
-    },
-
+    }
 });

--- a/prefs.js
+++ b/prefs.js
@@ -49,11 +49,9 @@ function init()
 	}
 }
 
-const App = new Lang.Class(
+const App = class NetSpeed_App
 {
-    Name: 'NetSpeed.App',
-
-    _get_dev_combo: function()
+    _get_dev_combo()
     {
         let listStore = new Gtk.ListStore();
         listStore.set_column_types ([GObject.TYPE_STRING, GObject.TYPE_STRING]);
@@ -110,9 +108,9 @@ const App = new Lang.Class(
         combo.add_attribute (rendererText, "text", 0);
         combo.add_attribute (rendererPixbuf, "icon_name", 1);
         return combo;
-    },
+    }
 
-    _put_dev: function()
+    _put_dev()
     {
         let active = this.dev.get_active();
         if (active == -1)
@@ -129,9 +127,9 @@ const App = new Lang.Class(
             Schema.set_string ('device', this._devices[active - 2].interface);
         }
         this._setting = 0;
-    },
+    }
 
-    _pick_dev: function()
+    _pick_dev()
     {
         if (this._setting == 1)
             return;
@@ -147,9 +145,9 @@ const App = new Lang.Class(
                     active = i + 2;
         }
         this.dev.set_active (active);
-    },
+    }
 
-    _init: function()
+    constructor()
     {
         this.main = new Gtk.Grid({row_spacing: 10, column_spacing: 20, column_homogeneous: false, row_homogeneous: true});
         this.main.attach (new Gtk.Label({label: _("Device to monitor")}), 1, 1, 1, 1);
@@ -226,7 +224,7 @@ const App = new Lang.Class(
 
         this.main.show_all();
     }
-});
+};
 
 function buildPrefsWidget()
 {


### PR DESCRIPTION
GNOME Shell 3.32 removed Lang.class() and we should be using ES6 classes instead. See https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/361

This change is mostly automated by https://github.com/DreaminginCodeZH/gnome-shell-es6-class-codemod , plus some minor fixes. I've verified this locally on my GNOME Shell 3.32.

Also updated the `shell-version` in `metadata.json` because I've no idea if this will work on 3.30, or even older releases. If someone is able to verify it works, we can add it back.

This change fixes #88.