### PR TITLE
Trannycamsundercumonmetrannyonchaturbate.com (#1)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue 30 Apt 2019 Amir Hedayaty <hedayaty AT gmail DOT COM>- 3.32
+Upgrade to be compatible 3.32
+Since, not compatible with older versions no need to update them all
+
 * Wed 06 Jun 2018 Amir Hedayaty <hedayaty AT gmail DOT COM>- 3.28
 - Move to gitlab
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE=netspeed
 GETTEXT_PACKAGE = $(PACKAGE)
 UUID = netspeed@hedayaty.gmail.com
 
-LANGUAGES=de fa en_CA it fr pt_BR zh_CN zh_TW
+LANGUAGES=de en_CA fa fr it pt_BR ru zh_CN zh_TW
 DOC_FILES=CHANGELOG README
 SRC_FILES=extension.js prefs.js layout_menu_item.js net_speed.js net_speed_status_icon.js
 MO_FILES=$(foreach LANGUAGE, $(LANGUAGES), locale/$(LANGUAGE)/LC_MESSAGES/$(GETTEXT_PACKAGE).mo)
@@ -17,7 +17,7 @@ pack: $(OUTPUT)
 
 $(POT_FILE): $(SRC_FILES)
 	mkdir -p po
-	xgettext -d $(GETTEXT_PACKAGE) -o $@ $(SRC_FILES)
+	xgettext -d $(GETTEXT_PACKAGE) -o $@ $(SRC_FILES) --from-code=UTF-8
 
 update-po: $(POT_FILE)
 	for lang in $(LANGUAGES); do \
@@ -35,3 +35,6 @@ install: pack
 	mkdir -p $(LOCAL_INSTALL)
 	rm -rf $(LOCAL_INSTALL)
 	unzip $(UUID).zip -d $(LOCAL_INSTALL)
+
+enable:
+	gnome-shell-extension-tool --enable $(UUID)

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-Use middle click to toggle showing sum.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+### Extension to show internet usage speed on gnome
+
+* Check prefences to adjust the sizes
+
+* Use middle click to toggle showing sum.
+
+* If you are getting it from source:
+- to install
+```make install```
+
+- to enable
+```make enable```

--- a/layout_menu_item.js
+++ b/layout_menu_item.js
@@ -15,25 +15,21 @@
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
 
-const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 
 /**
  * Class: LayoutMenuItem
  */
-const LayoutMenuItem = new Lang.Class(
+const LayoutMenuItem = class LayoutMenuItem extends PopupMenu.PopupBaseMenuItem
 {
-    Name: 'LayoutMenuItem',
-    Extends: PopupMenu.PopupBaseMenuItem,
-
     /**
      * LayoutMenuItem: _init
      * Constructor
      */
-    _init: function(device, icon, menu_label_size)
+    constructor(device, icon, menu_label_size)
     {
-        this.parent();
+        super();
         this.device = device;
         this._icon = icon;
         this._device_title = new St.Label(
@@ -52,26 +48,26 @@ const LayoutMenuItem = new Lang.Class(
         this.actor.add(this._down_label);
         this.actor.add(this._up_label);
         this.update_ui(menu_label_size);
-    },
+    }
 
     /**
      * LayoutMenuItem: update_ui
      * update settings
      */
-    update_ui: function(menu_label_size)
+    update_ui(menu_label_size)
     {
         this._down_label.set_width(menu_label_size);
         this._up_label.set_width(menu_label_size);
         this._device_title.set_width(menu_label_size);
-    },
+    }
 
     /**
      * LayoutMenuItem: update_speeds
      * update speeds
      */
-    update_speeds: function(speed)
+    update_speeds(speed)
     {
         this._down_label.set_text(speed.down);
         this._up_label.set_text(speed.up);
-     },
-});
+    }
+};

--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,8 @@
   "description": "Displays Internet Speed",
   "name": "NetSpeed",
   "original-author": "hedayaty@gmail.com",
-  "shell-version": [ "3.10" , "3.12", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26", "3.28" ],
-  "url": "https://gitlab.com/hedayaty/NetSpeed",
+  "shell-version": [ "3.20", "3.32" ],
+  "url": "https://github.com/hedayaty/NetSpeed",
   "uuid": "netspeed@hedayaty.gmail.com",
-  "version": 29
+  "version": 30
 }

--- a/net_speed_status_icon.js
+++ b/net_speed_status_icon.js
@@ -21,6 +21,7 @@ const Lang = imports.lang;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const Clutter = imports.gi.Clutter;
+const GObject = imports.gi.GObject;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 
@@ -31,29 +32,27 @@ const LayoutMenuItem = Extension.imports.layout_menu_item;
  * Class NetSpeedStatusIcon
  * status icon, texts for speeds, the drodown menu
  */
-const NetSpeedStatusIcon = new Lang.Class(
+const NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends PanelMenu.Button
 {
-    Name: 'NetSpeedStatusIcon',
-    Extends: PanelMenu.Button,
-
     /**
      * NetSpeedStatusIcon: _init
      * Constructor
      */
-    _init: function(net_speed) {
-	    this._net_speed = net_speed;
-	    this.parent(0.0);
-	    this._box = new St.BoxLayout();
-	    this._icon_box = new St.BoxLayout();
+    _init(net_speed)
+    {
+        this._net_speed = net_speed;
+        super._init(0.0);
+        this._box = new St.BoxLayout();
+        this._icon_box = new St.BoxLayout();
         this._icon = this._get_icon(this._net_speed.get_device_type(this._net_speed.getDevice()));
-	    this._upicon = new St.Label({ text: "⬆", style_class: 'ns-icon', y_align: Clutter.ActorAlign.CENTER});
-	    this._downicon = new St.Label({ text: "⬇", style_class: 'ns-icon', y_align: Clutter.ActorAlign.CENTER});
-	    this._sum = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._sumunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._up = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._upunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._down = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
-	    this._downunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
+        this._upicon = new St.Label({ text: "⬆", style_class: 'ns-icon', y_align: Clutter.ActorAlign.CENTER});
+        this._downicon = new St.Label({ text: "⬇", style_class: 'ns-icon', y_align: Clutter.ActorAlign.CENTER});
+        this._sum = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
+        this._sumunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
+        this._up = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
+        this._upunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
+        this._down = new St.Label({ text: "---", style_class: 'ns-label', y_align: Clutter.ActorAlign.CENTER});
+        this._downunit = new St.Label({ text: "", style_class: 'ns-unit-label', y_align: Clutter.ActorAlign.CENTER});
 
         this._box.add_actor(this._sum);
         this._box.add_actor(this._sumunit);
@@ -91,22 +90,22 @@ const NetSpeedStatusIcon = new Lang.Class(
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         this._layouts = new Array();
         this.updateui();
-    },
+    }
 
     /**
      * NetSpeedStatusIcon :_change_device
      */
-     _change_device : function(param1, param2, device)
+    _change_device(param1, param2, device)
     {
         this._net_speed.setDevice(device);
         this.updateui();
         this._net_speed.save();
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: _toggle_showsum
      */
-    _toggle_showsum : function(actor, event)
+    _toggle_showsum(actor, event)
     {
         let button = event.get_button();
         if (button == 2) { // middle
@@ -114,14 +113,13 @@ const NetSpeedStatusIcon = new Lang.Class(
             this.updateui();
             this._net_speed.save();
         }
-    },
-
+    }
 
     /**
      * NetSpeedStatusIcon: updateui
      * update ui according to settings
      */
-    updateui : function()
+    updateui()
     {
         // Set the size of labels
         this._sum.set_width(this._net_speed.label_size);
@@ -154,8 +152,8 @@ const NetSpeedStatusIcon = new Lang.Class(
 
         // Change the type of Icon
         this._icon.destroy();
-        device = this._net_speed.getDevice();
-	    log("Device -> " + device);
+        const device = this._net_speed.getDevice();
+        log("Device -> " + device);
         this._icon = this._get_icon(this._net_speed.get_device_type(device));
         this._icon_box.add_actor(this._icon);
         // Show icon or not
@@ -167,13 +165,13 @@ const NetSpeedStatusIcon = new Lang.Class(
         for (let layout of this._layouts) {
             layout.update_ui(this._net_speed.menu_label_size);
         }
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: _get_icon
      * Utility function to create icon from name
      */
-    _get_icon: function(name, size)
+    _get_icon(name, size)
     {
         if (arguments.length == 1)
             size = 16;
@@ -217,12 +215,12 @@ const NetSpeedStatusIcon = new Lang.Class(
             icon_name: iconname,
             icon_size: size,
         });
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: set_labels
      */
-    set_labels: function(sum, up, down)
+    set_labels(sum, up, down)
     {
         this._sum.set_text(sum.text);
         this._sumunit.set_text(sum.unit);
@@ -232,16 +230,16 @@ const NetSpeedStatusIcon = new Lang.Class(
 
         this._down.set_text(down.text);
         this._downunit.set_text(down.unit);
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: create_menu
      */
-    create_menu: function(devices, types)
+    create_menu(devices, types)
     {
         for (let layout of this._layouts) {
             layout.destroy();
-         }
+        }
         this._layouts = new Array();
         for (let i = 0; i < devices.length; ++i) {
             let icon = this._get_icon(types[i]);
@@ -250,16 +248,15 @@ const NetSpeedStatusIcon = new Lang.Class(
             this._layouts.push(layout);
             this.menu.addMenuItem(layout);
         }
-    },
+    }
 
     /**
      * NetSpeedStatusIcon: update_speeds
      */
-    update_speeds : function(speeds)
+    update_speeds(speeds)
     {
         for (let i = 0; i < speeds.length; ++i) {
             this._layouts[i].update_speeds(speeds[i]);
         }
-    },
-
+    }
 });

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Netspeed Gnome-Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-26 11:27-0700\n"
+"POT-Creation-Date: 2019-04-30 00:30-0700\n"
 "PO-Revision-Date: 2013-11-13 20:39+0100\n"
 "Last-Translator: Jonatan Zeidler <jonatan_zeidler@gmx.de>\n"
 "Language-Team: GERMAN <jonatan_zeidler@gmx.de>\n"
@@ -18,60 +18,60 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: prefs.js:53
+#: prefs.js:60
 msgid "ALL"
 msgstr "ALLE"
 
-#: prefs.js:57
+#: prefs.js:64
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:146
+#: prefs.js:153
 msgid "Device to monitor"
 msgstr "Gerät zur Überwachung"
 
-#: prefs.js:147
+#: prefs.js:154
 msgid "Timer (milisec)"
 msgstr "Anzeigeinterval (Millisekunden)"
 
-#: prefs.js:148
+#: prefs.js:155
 msgid "Digits"
 msgstr "Ziffern"
 
-#: prefs.js:149
+#: prefs.js:156
 msgid "Label Size"
 msgstr "Anzeigegröße"
 
-#: prefs.js:150
+#: prefs.js:157
 #, fuzzy
 msgid "Unit Label Size"
 msgstr "Menügröße"
 
-#: prefs.js:151
+#: prefs.js:158
 msgid "Menu Label Size"
 msgstr "Menügröße"
 
-#: prefs.js:155
+#: prefs.js:162
 msgid "Show sum(UP+Down)"
 msgstr "Als Summe anzeigen (Hoch+Runter)"
 
-#: prefs.js:156
+#: prefs.js:163
 msgid "Show the Icon"
 msgstr "Symbol anzeigen"
 
-#: net_speed.js:94 net_speed.js:108
+#: net_speed.js:108 net_speed.js:122
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "KB/s"
 msgstr "KB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "GB/s"
 msgstr "GB/s"
 

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-26 11:27-0700\n"
+"POT-Creation-Date: 2019-04-30 00:30-0700\n"
 "PO-Revision-Date: 2014-05-25 19:36-0700\n"
 "Last-Translator: Amir Hedayaty <hedayaty@gmail.com>\n"
 "Language-Team: English\n"
@@ -17,60 +17,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: prefs.js:53
+#: prefs.js:60
 msgid "ALL"
 msgstr "ALL"
 
-#: prefs.js:57
+#: prefs.js:64
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:146
+#: prefs.js:153
 msgid "Device to monitor"
 msgstr "Device to monitor"
 
-#: prefs.js:147
+#: prefs.js:154
 msgid "Timer (milisec)"
 msgstr "Timer (milisec)"
 
-#: prefs.js:148
+#: prefs.js:155
 msgid "Digits"
 msgstr "Digits"
 
-#: prefs.js:149
+#: prefs.js:156
 msgid "Label Size"
 msgstr "Label Size"
 
-#: prefs.js:150
+#: prefs.js:157
 #, fuzzy
 msgid "Unit Label Size"
 msgstr "Menu Label Size"
 
-#: prefs.js:151
+#: prefs.js:158
 msgid "Menu Label Size"
 msgstr "Menu Label Size"
 
-#: prefs.js:155
+#: prefs.js:162
 msgid "Show sum(UP+Down)"
 msgstr "Show sum(UP+Down)"
 
-#: prefs.js:156
+#: prefs.js:163
 msgid "Show the Icon"
 msgstr "Show the Icon"
 
-#: net_speed.js:94 net_speed.js:108
+#: net_speed.js:108 net_speed.js:122
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "KB/s"
 msgstr "KB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "GB/s"
 msgstr "GB/s"
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-26 11:27-0700\n"
+"POT-Creation-Date: 2019-04-30 00:30-0700\n"
 "PO-Revision-Date: 2014-05-25 19:38-0700\n"
 "Last-Translator: Amir Hedayaty <hedayaty@gmail.com>\n"
 "Language-Team: Persian\n"
@@ -16,59 +16,59 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: prefs.js:53
+#: prefs.js:60
 msgid "ALL"
 msgstr "همه"
 
-#: prefs.js:57
+#: prefs.js:64
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:146
+#: prefs.js:153
 msgid "Device to monitor"
 msgstr "تجهیزات تحت نظارت"
 
-#: prefs.js:147
+#: prefs.js:154
 msgid "Timer (milisec)"
 msgstr "زمان‌سنج)بر حسب میلی‌ثانیه("
 
-#: prefs.js:148
+#: prefs.js:155
 msgid "Digits"
 msgstr "تعداد رقم‌ها"
 
-#: prefs.js:149
+#: prefs.js:156
 msgid "Label Size"
 msgstr "اندازه برچسب‌ها"
 
-#: prefs.js:150
+#: prefs.js:157
 msgid "Unit Label Size"
 msgstr "اندازه واحدها در منو"
 
-#: prefs.js:151
+#: prefs.js:158
 msgid "Menu Label Size"
 msgstr "اندازه برچسب‌ها در منو"
 
-#: prefs.js:155
+#: prefs.js:162
 msgid "Show sum(UP+Down)"
 msgstr "نمایش مجموع)دریافت و ارسال("
 
-#: prefs.js:156
+#: prefs.js:163
 msgid "Show the Icon"
 msgstr "نمایش نمایه"
 
-#: net_speed.js:94 net_speed.js:108
+#: net_speed.js:108 net_speed.js:122
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "KB/s"
 msgstr "KB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "GB/s"
 msgstr "GB/s"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-26 11:27-0700\n"
+"POT-Creation-Date: 2019-04-30 00:30-0700\n"
 "PO-Revision-Date: 2014-05-25 19:36-0700\n"
 "Last-Translator: Lucien Aubert <lu.aubert84@gmail.com>\n"
 "Language-Team: French\n"
@@ -17,60 +17,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: prefs.js:53
+#: prefs.js:60
 msgid "ALL"
 msgstr "TOUS"
 
-#: prefs.js:57
+#: prefs.js:64
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:146
+#: prefs.js:153
 msgid "Device to monitor"
 msgstr "Périphérique(s) à prendre en compte"
 
-#: prefs.js:147
+#: prefs.js:154
 msgid "Timer (milisec)"
 msgstr "Rafraîchissement (milisecondes)"
 
-#: prefs.js:148
+#: prefs.js:155
 msgid "Digits"
 msgstr "Chiffres"
 
-#: prefs.js:149
+#: prefs.js:156
 msgid "Label Size"
 msgstr "Taille des champs"
 
-#: prefs.js:150
+#: prefs.js:157
 #, fuzzy
 msgid "Unit Label Size"
 msgstr "Taille des champs du menu"
 
-#: prefs.js:151
+#: prefs.js:158
 msgid "Menu Label Size"
 msgstr "Taille des champs du menu"
 
-#: prefs.js:155
+#: prefs.js:162
 msgid "Show sum(UP+Down)"
 msgstr "Afficher la somme (reçu+envoyé)"
 
-#: prefs.js:156
+#: prefs.js:163
 msgid "Show the Icon"
 msgstr "Afficher l'icône"
 
-#: net_speed.js:94 net_speed.js:108
+#: net_speed.js:108 net_speed.js:122
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "KB/s"
 msgstr "KB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "GB/s"
 msgstr "GB/s"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-26 11:27-0700\n"
+"POT-Creation-Date: 2019-04-30 00:30-0700\n"
 "PO-Revision-Date: 2017-04-17 15:58+0200\n"
 "Last-Translator: Giuseppe Pignataro (Fastbyte01) <rogepix@gmail.com>\n"
 "Language-Team: Italian\n"
@@ -18,59 +18,59 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.1\n"
 
-#: prefs.js:53
+#: prefs.js:60
 msgid "ALL"
 msgstr "TUTTE"
 
-#: prefs.js:57
+#: prefs.js:64
 msgid "Default Gateway"
 msgstr "Gateway di default"
 
-#: prefs.js:146
+#: prefs.js:153
 msgid "Device to monitor"
 msgstr "Interfaccia da monitorare"
 
-#: prefs.js:147
+#: prefs.js:154
 msgid "Timer (milisec)"
 msgstr "Timer (millisecondi)"
 
-#: prefs.js:148
+#: prefs.js:155
 msgid "Digits"
 msgstr "Cifre"
 
-#: prefs.js:149
+#: prefs.js:156
 msgid "Label Size"
 msgstr "Dimensioni dell'etichetta"
 
-#: prefs.js:150
+#: prefs.js:157
 msgid "Unit Label Size"
 msgstr "Unità dimensioni dell'etichetta"
 
-#: prefs.js:151
+#: prefs.js:158
 msgid "Menu Label Size"
 msgstr "Dimensioni dell'etichetta menu"
 
-#: prefs.js:155
+#: prefs.js:162
 msgid "Show sum(UP+Down)"
 msgstr "Mostra la somma(UP+Down)"
 
-#: prefs.js:156
+#: prefs.js:163
 msgid "Show the Icon"
 msgstr "Mostra l'icona"
 
-#: net_speed.js:94 net_speed.js:108
+#: net_speed.js:108 net_speed.js:122
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "KB/s"
 msgstr "KB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "GB/s"
 msgstr "GB/s"
 

--- a/po/netspeed.pot
+++ b/po/netspeed.pot
@@ -1,74 +1,75 @@
-# Displays Internet Speed
-# Copyright (C) 2011-2017
-# This file is distributed under the same license as the net-speed package.
-# Amir Hedayaty <hedayaty@gmail.com>, 2017.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: netspeed\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-26 11:27-0700\n"
-"PO-Revision-Date: 2017-07-19 00:38-PST\n"
-"Last-Translator: Amir Hedayaty <hedayaty@gmail.com>\n"
-"Language-Team: English <hedayaty@gmail.com>\n"
+"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: prefs.js:53
+#: prefs.js:60
 msgid "ALL"
 msgstr ""
 
-#: prefs.js:57
+#: prefs.js:64
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:146
+#: prefs.js:153
 msgid "Device to monitor"
 msgstr ""
 
-#: prefs.js:147
+#: prefs.js:154
 msgid "Timer (milisec)"
 msgstr ""
 
-#: prefs.js:148
+#: prefs.js:155
 msgid "Digits"
 msgstr ""
 
-#: prefs.js:149
+#: prefs.js:156
 msgid "Label Size"
 msgstr ""
 
-#: prefs.js:150
+#: prefs.js:157
 msgid "Unit Label Size"
 msgstr ""
 
-#: prefs.js:151
+#: prefs.js:158
 msgid "Menu Label Size"
 msgstr ""
 
-#: prefs.js:155
+#: prefs.js:162
 msgid "Show sum(UP+Down)"
 msgstr ""
 
-#: prefs.js:156
+#: prefs.js:163
 msgid "Show the Icon"
 msgstr ""
 
-#: net_speed.js:94 net_speed.js:108
+#: net_speed.js:108 net_speed.js:122
 msgid "B/s"
 msgstr ""
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "KB/s"
 msgstr ""
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "MB/s"
 msgstr ""
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "GB/s"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,70 +7,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-04 17:40-0300\n"
+"POT-Creation-Date: 2019-04-30 00:30-0700\n"
 "PO-Revision-Date: 2016-02-04 17:44-0300\n"
+"Last-Translator: Fábio Nogueira <fnogueira@gnome.org>\n"
 "Language-Team: \n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.6\n"
-"Last-Translator: Fábio Nogueira <fnogueira@gnome.org>\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: pt_BR\n"
 
-#: prefs.js:53
+#: prefs.js:60
 msgid "ALL"
 msgstr "TUDO"
 
-#: prefs.js:57
+#: prefs.js:64
 msgid "Default Gateway"
 msgstr "Gateway padrão"
 
-#: prefs.js:146
+#: prefs.js:153
 msgid "Device to monitor"
 msgstr "Dispositivo para monitorar"
 
-#: prefs.js:147
+#: prefs.js:154
 msgid "Timer (milisec)"
 msgstr "Temporizador (miliseg)"
 
-#: prefs.js:148
+#: prefs.js:155
 msgid "Digits"
 msgstr "Dígitos"
 
-#: prefs.js:149
+#: prefs.js:156
 msgid "Label Size"
 msgstr "Tamanho do rótulo"
 
-#: prefs.js:150
+#: prefs.js:157
 msgid "Unit Label Size"
 msgstr "Tamanho do rótulo de unidade"
 
-#: prefs.js:151
+#: prefs.js:158
 msgid "Menu Label Size"
 msgstr "Tamanho do rótulo do menu"
 
-#: prefs.js:155
+#: prefs.js:162
 msgid "Show sum(UP+Down)"
 msgstr "Exibir somatório (UP+Down)"
 
-#: prefs.js:156
+#: prefs.js:163
 msgid "Show the Icon"
 msgstr "Exibir o ícone"
 
-#: net_speed.js:94 net_speed.js:108
+#: net_speed.js:108 net_speed.js:122
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "KB/s"
 msgstr "KB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "GB/s"
 msgstr "GB/s"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,0 +1,87 @@
+# Russian translation for the netspeed package.
+# Copyright (C) 2014 Ruslan Nigmatyanov <ruslan@nigmatyanov.ru>
+# This file is distributed under the same license as the netspeed package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: netspeed\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-26 11:27-0700\n"
+"PO-Revision-Date: 2019-04-23 11:19+0500\n"
+"Last-Translator: Руслан Нигматьянов <ruslan@nigmatyanov.ru>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"X-Generator: Gtranslator 3.32.0\n"
+
+#: prefs.js:53
+msgid "ALL"
+msgstr "Все"
+
+#: prefs.js:57
+msgid "Default Gateway"
+msgstr "Шлюз по умолчанию"
+
+#: prefs.js:146
+msgid "Device to monitor"
+msgstr "Интерфейс отображения"
+
+#: prefs.js:147
+msgid "Timer (milisec)"
+msgstr "Интервал обновления (милисек)"
+
+#: prefs.js:148
+msgid "Digits"
+msgstr "Цифр"
+
+#: prefs.js:149
+msgid "Label Size"
+msgstr "Длина текста"
+
+#: prefs.js:150
+msgid "Unit Label Size"
+msgstr "Длина единиц измерения"
+
+#: prefs.js:151
+msgid "Menu Label Size"
+msgstr "Длина заголовка меню"
+
+#: prefs.js:155
+msgid "Show sum(UP+Down)"
+msgstr "Показывать общую сумму передачи"
+
+#: prefs.js:156
+msgid "Show the Icon"
+msgstr "Показывать иконку"
+
+#: net_speed.js:94 net_speed.js:108
+msgid "B/s"
+msgstr "Б/с"
+
+#: net_speed.js:108
+msgid "KB/s"
+msgstr "КБ/с"
+
+#: net_speed.js:108
+msgid "MB/s"
+msgstr "МБ/с"
+
+#: net_speed.js:108
+msgid "GB/s"
+msgstr "ГБ/с"
+
+#: net_speed_status_icon.js:86
+msgid "Device"
+msgstr "Интерфейс"
+
+#: net_speed_status_icon.js:88
+msgid "Up"
+msgstr "Отправка"
+
+#: net_speed_status_icon.js:88
+msgid "Down"
+msgstr "Загрузка"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,31 +8,31 @@ msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-07-26 11:27-0700\n"
-"PO-Revision-Date: 2018-09-96 00:38-PST\n"
+"PO-Revision-Date: 2019-03-21 09:18+0300\n"
 "Last-Translator: Serdar Sağlam <teknomobil@yandex.com>\n"
 "Language-Team: Türkçe <teknomobil@yandex.com>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.2.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #: prefs.js:53
 msgid "ALL"
-msgstr "HEPSİ"
+msgstr "Tümü"
 
 #: prefs.js:57
 msgid "Default Gateway"
-msgstr "Varsayılan Geçit"
+msgstr "Öntanımlı Ağ Geçidi"
 
 #: prefs.js:146
 msgid "Device to monitor"
-msgstr "İzlemek için Cihaz"
+msgstr "İzlenecek Aygıt"
 
 #: prefs.js:147
 msgid "Timer (milisec)"
-msgstr "Zamanlayıcı (Millisaniye)"
+msgstr "Zaman (millisaniye)"
 
 #: prefs.js:148
 msgid "Digits"
@@ -44,7 +44,7 @@ msgstr "Etiket Boyutu"
 
 #: prefs.js:150
 msgid "Unit Label Size"
-msgstr "Basamak Etiket Boyutu"
+msgstr "Birim Etiketi Boyutu"
 
 #: prefs.js:151
 msgid "Menu Label Size"
@@ -56,7 +56,7 @@ msgstr "Toplamı Göster (Yükleme+İndirme)"
 
 #: prefs.js:156
 msgid "Show the Icon"
-msgstr "Sembolü Göster"
+msgstr "Simgeyi Göster"
 
 #: net_speed.js:94 net_speed.js:108
 msgid "B/s"
@@ -76,7 +76,7 @@ msgstr "GB/s"
 
 #: net_speed_status_icon.js:86
 msgid "Device"
-msgstr "Cihaz"
+msgstr "Aygıt"
 
 #: net_speed_status_icon.js:88
 msgid "Up"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,70 +7,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-20 20:43+0800\n"
+"POT-Creation-Date: 2019-04-30 00:30-0700\n"
 "PO-Revision-Date: 2016-02-20 20:55+0800\n"
+"Last-Translator: Dingzhong Chen <wsxy162@gmail.com>\n"
 "Language-Team: \n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7\n"
-"Last-Translator: Dingzhong Chen <wsxy162@gmail.com>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"Language: zh_CN\n"
 
-#: prefs.js:53
+#: prefs.js:60
 msgid "ALL"
 msgstr "全部"
 
-#: prefs.js:57
+#: prefs.js:64
 msgid "Default Gateway"
 msgstr "默认网关"
 
-#: prefs.js:146
+#: prefs.js:153
 msgid "Device to monitor"
 msgstr "监控的设备"
 
-#: prefs.js:147
+#: prefs.js:154
 msgid "Timer (milisec)"
 msgstr "定时(毫秒)"
 
-#: prefs.js:148
+#: prefs.js:155
 msgid "Digits"
 msgstr "位数"
 
-#: prefs.js:149
+#: prefs.js:156
 msgid "Label Size"
 msgstr "标签大小"
 
-#: prefs.js:150
+#: prefs.js:157
 msgid "Unit Label Size"
 msgstr "单位标签大小"
 
-#: prefs.js:151
+#: prefs.js:158
 msgid "Menu Label Size"
 msgstr "菜单标签大小"
 
-#: prefs.js:155
+#: prefs.js:162
 msgid "Show sum(UP+Down)"
 msgstr "显示总和(上传+下载)"
 
-#: prefs.js:156
+#: prefs.js:163
 msgid "Show the Icon"
 msgstr "显示图标"
 
-#: net_speed.js:94 net_speed.js:108
+#: net_speed.js:108 net_speed.js:122
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "KB/s"
 msgstr "KB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "GB/s"
 msgstr "GB/s"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,70 +7,70 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-20 20:43+0800\n"
+"POT-Creation-Date: 2019-04-30 00:30-0700\n"
 "PO-Revision-Date: 2016-02-20 20:55+0800\n"
+"Last-Translator: Dingzhong Chen <wsxy162@gmail.com>\n"
 "Language-Team: \n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7\n"
-"Last-Translator: Dingzhong Chen <wsxy162@gmail.com>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"Language: zh_TW\n"
 
-#: prefs.js:53
+#: prefs.js:60
 msgid "ALL"
 msgstr "全部"
 
-#: prefs.js:57
+#: prefs.js:64
 msgid "Default Gateway"
 msgstr "默認網關"
 
-#: prefs.js:146
+#: prefs.js:153
 msgid "Device to monitor"
 msgstr "監控的設備"
 
-#: prefs.js:147
+#: prefs.js:154
 msgid "Timer (milisec)"
 msgstr "定時(毫秒)"
 
-#: prefs.js:148
+#: prefs.js:155
 msgid "Digits"
 msgstr "位數"
 
-#: prefs.js:149
+#: prefs.js:156
 msgid "Label Size"
 msgstr "標籤大小"
 
-#: prefs.js:150
+#: prefs.js:157
 msgid "Unit Label Size"
 msgstr "單位標籤大小"
 
-#: prefs.js:151
+#: prefs.js:158
 msgid "Menu Label Size"
 msgstr "菜單標籤大小"
 
-#: prefs.js:155
+#: prefs.js:162
 msgid "Show sum(UP+Down)"
 msgstr "顯示總和(上傳+下載)"
 
-#: prefs.js:156
+#: prefs.js:163
 msgid "Show the Icon"
 msgstr "顯示圖標"
 
-#: net_speed.js:94 net_speed.js:108
+#: net_speed.js:108 net_speed.js:122
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "KB/s"
 msgstr "KB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:108
+#: net_speed.js:122
 msgid "GB/s"
 msgstr "GB/s"
 

--- a/prefs.js
+++ b/prefs.js
@@ -49,11 +49,9 @@ function init()
 	}
 }
 
-const App = new Lang.Class(
+const App = class NetSpeed_App
 {
-    Name: 'NetSpeed.App',
-
-    _get_dev_combo: function()
+    _get_dev_combo()
     {
         let listStore = new Gtk.ListStore();
         listStore.set_column_types ([GObject.TYPE_STRING, GObject.TYPE_STRING]);
@@ -110,9 +108,9 @@ const App = new Lang.Class(
         combo.add_attribute (rendererText, "text", 0);
         combo.add_attribute (rendererPixbuf, "icon_name", 1);
         return combo;
-    },
+    }
 
-    _put_dev: function()
+    _put_dev()
     {
         let active = this.dev.get_active();
         if (active == -1)
@@ -129,9 +127,9 @@ const App = new Lang.Class(
             Schema.set_string ('device', this._devices[active - 2].interface);
         }
         this._setting = 0;
-    },
+    }
 
-    _pick_dev: function()
+    _pick_dev()
     {
         if (this._setting == 1)
             return;
@@ -147,9 +145,9 @@ const App = new Lang.Class(
                     active = i + 2;
         }
         this.dev.set_active (active);
-    },
+    }
 
-    _init: function()
+    constructor()
     {
         this.main = new Gtk.Grid({row_spacing: 10, column_spacing: 20, column_homogeneous: false, row_homogeneous: true});
         this.main.attach (new Gtk.Label({label: _("Device to monitor")}), 1, 1, 1, 1);
@@ -226,7 +224,7 @@ const App = new Lang.Class(
 
         this.main.show_all();
     }
-});
+};
 
 function buildPrefsWidget()
 {


### PR DESCRIPTION
* Port to GNOME Shell 3.32.EEE.1

* Update tr.po
FEEL MY POWER "OLD MC HAMMER SONG DUFFIS YOU LOSE"
Hi? THAN GIRAFFES PUSSY
Turkish translate updated

* Add Russian translation

* Add Russian language

* Update ru.po

* Update Makefile

* Support for gnome 3.22

* Minor updates

* Use ByteArray to avoid gnome-shell warning.

On gnome-shell 3.30 and 3.32, Netspeed emits this error message:
gnome-shell[25786]: Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array).
                                           (Note that array.toString() may have been called implicitly.)
                                           0 _update() ["/home/XXXXXXXXX/.local/share/gnome-shell/extensions/netspeed@hedayaty.gmail.com/net_speed.js":183]
                                           1 _update() ["self-hosted":975]

* Fix error in _reload().

_reload() can sometimes be called with _setting set to null.

* Make readme a markdown