### PR TITLE
Show IP alongside each interface in panel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ UUID = netspeed@hedayaty.gmail.com
 
 LANGUAGES=ca de en_CA fa fr it pt_BR ru zh_CN zh_TW es_ES nl_NL ru tr zh_CN
 DOC_FILES=CHANGELOG README.md
-SRC_FILES=extension.js prefs.js net_speed_layout_menu_item.js net_speed.js net_speed_status_icon.js
+SRC_FILES=extension.js prefs.js net_speed_layout_menu_item.js net_speed.js net_speed_status_icon.js lib.js
 MO_FILES=$(foreach LANGUAGE, $(LANGUAGES), locale/$(LANGUAGE)/LC_MESSAGES/$(GETTEXT_PACKAGE).mo)
 SCHEMA_FILES=schemas/gschemas.compiled schemas/org.gnome.shell.extensions.netspeed.gschema.xml
 EXTENSION_FILES=stylesheet.css metadata.json

--- a/lib.js
+++ b/lib.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2011-2019 Amir Hedayaty < hedayaty AT gmail DOT com >
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const Extension = imports.misc.extensionUtils.getCurrentExtension();
+const GLib = imports.gi.GLib;
+const Config = imports.misc.config;
+
+// Schema name
+var SCHEMA = "org.gnome.shell.extensions.netspeed";
+
+// Debug Mode Settings
+var DEBUG = true;
+
+// Logging
+const LOG_DOMAIN = SCHEMA;
+const LOG_PREFIX = `[${LOG_DOMAIN}]`;
+
+// Log all messages when connected to the journal if DEBUG
+//if (GLib.log_writer_is_journald(2) && DEBUG)
+//    GLib.setenv('G_MESSAGES_DEBUG', LOG_DOMAIN, false);
+
+/**
+ * A Logger class inspired to GJS doc/Logging.md
+ * 
+ * */
+var _loggerClass = class _Logger {
+
+    constructor(module) {
+    }
+
+    _getMessage(event, file, func, line) {
+        let timestamp = new Date(new Date().getTime()).toISOString();
+        let message = `${event}`;
+        if (DEBUG) {
+            message = `[${Extension.uuid}:${file}:${func}:${line}] ${event}`;
+        }
+        return message;
+    }
+
+    _makeLogFunction(level) {
+        return message => {
+            let stack = (new Error()).stack;
+            let caller = stack.split('\n')[2];
+
+            // caller example: message@/home/guser/.local/share/gnome-shell/extensions/netspeed@hedayaty.gmail.com/lib.js:75:9
+            // Extension.path: /home/guser/.local/share/gnome-shell/extensions/netspeed@hedayaty.gmail.com
+            caller = caller.replace(Extension.path + "/", "");
+
+            let [code, line, _] = caller.split(':');
+            let [func, file] = code.split(/\W*@/);
+            let msg = this._getMessage(message, file, func, line);
+            GLib.log_structured(LOG_DOMAIN, level, {
+                'MESSAGE': msg,
+                //'SYSLOG_IDENTIFIER': LOG_DOMAIN,
+                'CODE_FILE': file,
+                'CODE_FUNC': func,
+                'CODE_LINE': line
+            });
+        };
+    }
+
+    debug(event) {
+        this._makeLogFunction(GLib.LogLevelFlags.LEVEL_DEBUG)(event);
+    }
+
+    log(event) {
+        this._makeLogFunction(GLib.LogLevelFlags.LEVEL_MESSAGE)(event);
+    }
+
+    message(event) {
+        this._makeLogFunction(GLib.LogLevelFlags.LEVEL_MESSAGE)(event);
+    }
+
+    info(event) {
+        this._makeLogFunction(GLib.LogLevelFlags.LEVEL_INFO)(event);
+    }
+
+    warning(event) {
+        this._makeLogFunction(GLib.LogLevelFlags.LEVEL_WARNING)(event);
+    }
+
+    /*
+    error(event) {
+        // result in a core dump
+        this._makeLogFunction(GLib.LogLevelFlags.LEVEL_ERROR)(event);
+    }
+    */
+
+    critical(event) {
+        this._makeLogFunction(GLib.LogLevelFlags.LEVEL_CRITICAL)(event);
+    }
+}
+
+
+/**
+ * getLogger:
+ * @returns {_Logger} a new Logger instance if not exists
+ */
+let _loggerInstance;
+function getLogger() {
+    if (!_loggerInstance) {
+        _loggerInstance = new _loggerClass();
+    }
+    return _loggerInstance;
+}
+
+
+/**
+ * splitVersion:
+ * @param {string} version - the version we have in semantic versioning format
+ * @returns {int[2]} - an array of int for <major> and <minor> for @version
+ *
+ * @version must be in the format <major>.<minor>.<micro>.<pre-tag>
+ * <micro> and <pre-tag> are always ignored
+ * @version must be at least <major> and <minor>
+ */
+
+function splitVersion(version) {
+    let currentArray = version.split('.');
+    let major = parseInt(currentArray[0]);
+    let minor = parseInt(currentArray[1]);
+    return [major, minor];
+}
+
+
+/**
+ * showIPs:
+ * @returns {boolean} - true if panel can show IPs, false otherwise
+ */
+
+function showIPs() {
+
+    let version_array = splitVersion(Config.PACKAGE_VERSION);
+
+    // Gnome 3.32 have a bug on GObject introspection for GPtrArray
+    // so NetworkManager crash on returning ip_config
+    if (version_array[0] == 3 && (version_array[1] < 32 || version_array[1] >= 34)) {
+        getLogger().log(`Show IP can be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
+        return true;
+    }
+    getLogger().log(`Show IP cannot be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
+    Schema.set_boolean('show-ips', false);
+    return false;
+}

--- a/lib.js
+++ b/lib.js
@@ -29,9 +29,8 @@ var DEBUG = false;
 const LOG_DOMAIN = SCHEMA;
 const LOG_PREFIX = `[${LOG_DOMAIN}]`;
 
-// Log all messages when connected to the journal if DEBUG
-if (GLib.log_writer_is_journald(2) && DEBUG){
-    log("G_MESSAGES_DEBUG");
+// Log all messages when connected to the journal
+if (GLib.log_writer_is_journald(2) && DEBUG) {
     GLib.setenv('G_MESSAGES_DEBUG', LOG_DOMAIN, false);
 } else {
     // FIXME: manage already existing env var
@@ -41,7 +40,7 @@ if (GLib.log_writer_is_journald(2) && DEBUG){
 /**
  * A Logger class inspired to GJS doc/Logging.md
  * 
- * */
+ */
 var _loggerClass = class _Logger {
 
     constructor(module) {
@@ -152,7 +151,7 @@ function canShowIPs() {
 
     let version_array = splitVersion(Config.PACKAGE_VERSION);
 
-    
+
     if (version_array[0] == 3 && (version_array[1] < 28 || version_array[1] >= 34)) {
         getLogger().debug(`Show IP can be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
         return true;

--- a/lib.js
+++ b/lib.js
@@ -140,21 +140,21 @@ function splitVersion(version) {
 
 
 /**
- * showIPs:
+ * canShowIPs:
  * @returns {boolean} - true if panel can show IPs, false otherwise
  */
 
-function showIPs() {
+function canShowIPs() {
 
     let version_array = splitVersion(Config.PACKAGE_VERSION);
 
     // Gnome 3.32 have a bug on GObject introspection for GPtrArray
     // so NetworkManager crash on returning ip_config
     if (version_array[0] == 3 && (version_array[1] < 32 || version_array[1] >= 34)) {
-        getLogger().log(`Show IP can be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
+        getLogger().debug(`Show IP can be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
         return true;
     }
-    getLogger().log(`Show IP cannot be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
+    getLogger().warning(`Show IP cannot be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
     Schema.set_boolean('show-ips', false);
     return false;
 }

--- a/lib.js
+++ b/lib.js
@@ -23,15 +23,20 @@ const Config = imports.misc.config;
 var SCHEMA = "org.gnome.shell.extensions.netspeed";
 
 // Debug Mode Settings
-var DEBUG = true;
+var DEBUG = false;
 
 // Logging
 const LOG_DOMAIN = SCHEMA;
 const LOG_PREFIX = `[${LOG_DOMAIN}]`;
 
 // Log all messages when connected to the journal if DEBUG
-//if (GLib.log_writer_is_journald(2) && DEBUG)
-//    GLib.setenv('G_MESSAGES_DEBUG', LOG_DOMAIN, false);
+if (GLib.log_writer_is_journald(2) && DEBUG){
+    log("G_MESSAGES_DEBUG");
+    GLib.setenv('G_MESSAGES_DEBUG', LOG_DOMAIN, false);
+} else {
+    // FIXME: manage already existing env var
+    GLib.unsetenv('G_MESSAGES_DEBUG');
+}
 
 /**
  * A Logger class inspired to GJS doc/Logging.md
@@ -45,9 +50,7 @@ var _loggerClass = class _Logger {
     _getMessage(event, file, func, line) {
         let timestamp = new Date(new Date().getTime()).toISOString();
         let message = `${event}`;
-        if (DEBUG) {
-            message = `[${Extension.uuid}:${file}:${func}:${line}] ${event}`;
-        }
+        message = `[${Extension.uuid}:${file}:${func}:${line}] -> ${event}`;
         return message;
     }
 
@@ -126,7 +129,6 @@ function getLogger() {
  *
  * @version must be in the format <major>.<minor>.<micro>.<pre-tag>
  * <micro> and <pre-tag> are always ignored
- * @version must be at least <major> and <minor>
  */
 
 function splitVersion(version) {

--- a/lib.js
+++ b/lib.js
@@ -142,19 +142,21 @@ function splitVersion(version) {
 /**
  * canShowIPs:
  * @returns {boolean} - true if panel can show IPs, false otherwise
+ * 
+ * Gjs 1.56 (not sure) - 1.57 (Gnome 3.28 - 3.32) have a bug on Marshalling of GPtrArray,
+ * so NetworkManager js binding crash on returning ip_config. 
+ * https://gitlab.gnome.org/GNOME/gjs/issues/9
  */
 
 function canShowIPs() {
 
     let version_array = splitVersion(Config.PACKAGE_VERSION);
 
-    // Gnome 3.32 have a bug on GObject introspection for GPtrArray
-    // so NetworkManager crash on returning ip_config
-    if (version_array[0] == 3 && (version_array[1] < 32 || version_array[1] >= 34)) {
+    
+    if (version_array[0] == 3 && (version_array[1] < 28 || version_array[1] >= 34)) {
         getLogger().debug(`Show IP can be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
         return true;
     }
     getLogger().warning(`Show IP cannot be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
-    Schema.set_boolean('show-ips', false);
     return false;
 }

--- a/lib.js
+++ b/lib.js
@@ -151,7 +151,6 @@ function canShowIPs() {
 
     let version_array = splitVersion(Config.PACKAGE_VERSION);
 
-
     if (version_array[0] == 3 && (version_array[1] < 28 || version_array[1] >= 34)) {
         getLogger().debug(`Show IP can be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
         return true;

--- a/net_speed.js
+++ b/net_speed.js
@@ -387,7 +387,6 @@ var NetSpeed = class NetSpeed {
      * NetSpeed: _nm_device_changed
      */
     _nm_device_changed(client, device) {
-        log("_nm_device_changed");
         this._trigger_ips_reload();
     }
 
@@ -395,7 +394,6 @@ var NetSpeed = class NetSpeed {
      * NetSpeed: _nm_connection_changed
      */
     _nm_connection_changed(client, connection) {
-        log("_nm_connection_changed");
         this._trigger_ips_reload();
     }
     /**

--- a/net_speed.js
+++ b/net_speed.js
@@ -253,13 +253,11 @@ var NetSpeed = class NetSpeed {
 
             this._set_labels(total_speed, up_speed, down_speed);
             this._update_speeds();
-        } else
+        } else {
             this._create_menu();
+        }
 
-
-
-
-        if (this._reload_ips) {
+        if (this._reload_ips && this.show_ips) {
             this._retrieve_ips();
             this._update_ips();
         }

--- a/net_speed_layout_menu_item.js
+++ b/net_speed_layout_menu_item.js
@@ -53,6 +53,9 @@ var NetSpeedLayoutMenuItem = GObject.registerClass(
             this.add(this._up_label);
             this.add(this._ips_label);
             this.update_ui(menu_label_size);
+            this.show_ip(false);
+
+            //log(`${getMethods(this)}`);
         }
 
         /**
@@ -74,7 +77,11 @@ var NetSpeedLayoutMenuItem = GObject.registerClass(
             this._down_label.set_text(speed.down);
             this._up_label.set_text(speed.up);
         }
-
+        
+        /**
+         * NetSpeedLayoutMenuItem: show_ip
+         * @param {boolean} value 
+         */
         show_ip(value) {
             if (value) {
                 this._ips_label.show();
@@ -87,6 +94,7 @@ var NetSpeedLayoutMenuItem = GObject.registerClass(
         /**
          * NetSpeedLayoutMenuItem: update_ips
          * update ips
+         * @param {string[]} ips: IPs addresses array
          */
         update_ips(ips) {
             this._ips_label.set_text(ips.join("\n"));

--- a/net_speed_layout_menu_item.js
+++ b/net_speed_layout_menu_item.js
@@ -75,6 +75,15 @@ var NetSpeedLayoutMenuItem = GObject.registerClass(
             this._up_label.set_text(speed.up);
         }
 
+        show_ip(value) {
+            if (value) {
+                this._ips_label.show();
+            }
+            else {
+                this._ips_label.hide();
+            }
+        }
+
         /**
          * NetSpeedLayoutMenuItem: update_ips
          * update ips

--- a/net_speed_layout_menu_item.js
+++ b/net_speed_layout_menu_item.js
@@ -38,8 +38,11 @@ var NetSpeedLayoutMenuItem = GObject.registerClass(
                     , style_class: "ns-menuitem"
                 }
             );
+
             this._down_label = new St.Label({ text: "", style_class: "ns-menuitem" });
             this._up_label = new St.Label({ text: "", style_class: "ns-menuitem" });
+            this._ips_label = new St.Label({ text: "", style_class: "ns-menuitem" });
+
             if (this._icon != null) {
                 this.add(this._icon);
             } else {
@@ -48,6 +51,7 @@ var NetSpeedLayoutMenuItem = GObject.registerClass(
             this.add(this._device_title);
             this.add(this._down_label);
             this.add(this._up_label);
+            this.add(this._ips_label);
             this.update_ui(menu_label_size);
         }
 
@@ -59,6 +63,7 @@ var NetSpeedLayoutMenuItem = GObject.registerClass(
             this._down_label.set_width(menu_label_size);
             this._up_label.set_width(menu_label_size);
             this._device_title.set_width(menu_label_size);
+            this._ips_label.set_width(menu_label_size);
         }
 
         /**
@@ -69,4 +74,13 @@ var NetSpeedLayoutMenuItem = GObject.registerClass(
             this._down_label.set_text(speed.down);
             this._up_label.set_text(speed.up);
         }
+
+        /**
+         * NetSpeedLayoutMenuItem: update_ips
+         * update ips
+         */
+        update_ips(ips) {
+            this._ips_label.set_text(ips.join("\n"));
+        }
+
     });

--- a/net_speed_status_icon.js
+++ b/net_speed_status_icon.js
@@ -153,7 +153,7 @@ var NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends 
         this._icon.destroy();
         const device = this._net_speed.getDevice();
 
-        Logger.message("Device -> " + device);
+        Logger.debug("Device -> " + device);
 
         this._icon = this._get_icon(this._net_speed.get_device_type(device));
         this._icon_box.add_actor(this._icon);
@@ -214,8 +214,6 @@ var NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends 
                 iconname = "network-transmit-receive-symbolic";
         }
 
-        Logger.info(`Get icon for '${name}': '${iconname}'`);
-
         return new St.Icon({
             icon_name: iconname,
             icon_size: size,
@@ -247,6 +245,7 @@ var NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends 
         for (let i = 0; i < devices.length; ++i) {
             let icon = this._get_icon(types[i]);
             let layout = new NetSpeedLayoutMenuItem.NetSpeedLayoutMenuItem(devices[i], icon, this._net_speed.menu_label_size);
+            layout.show_ip(this._net_speed.show_ips);
             layout.connect("activate", Lang.bind(this, this._change_device, devices[i]));
             this._layouts.push(layout);
             this.menu.addMenuItem(layout);

--- a/net_speed_status_icon.js
+++ b/net_speed_status_icon.js
@@ -28,6 +28,9 @@ const St = imports.gi.St;
 const _ = Gettext.domain('netspeed').gettext;
 const NetSpeedLayoutMenuItem = Extension.imports.net_speed_layout_menu_item;
 
+const Lib = Extension.imports.lib;
+const Logger = Lib.getLogger();
+
 /**
  * Class NetSpeedStatusIcon
  * status icon, texts for speeds, the drop-down menu
@@ -83,6 +86,7 @@ var NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends 
         this._menu_title = new NetSpeedLayoutMenuItem.NetSpeedLayoutMenuItem(_("Device"), this._pref, this._net_speed.menu_label_size);
         this._menu_title.connect("activate", Lang.bind(this, this._change_device, ""));
         this._menu_title.update_speeds({ up: _("Up"), down: _("Down") });
+        this._menu_title.update_ips([_("IP")]);
         this.menu.addMenuItem(this._menu_title);
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         this._layouts = new Array();
@@ -147,7 +151,9 @@ var NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends 
         // Change the type of Icon
         this._icon.destroy();
         const device = this._net_speed.getDevice();
-        log("Device -> " + device);
+
+        Logger.message("Device -> " + device);
+
         this._icon = this._get_icon(this._net_speed.get_device_type(device));
         this._icon_box.add_actor(this._icon);
         // Show icon or not
@@ -202,8 +208,10 @@ var NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends 
                 iconname = "emblem-system-symbolic";
                 break;
             default:
-                iconname = "network-transmit-receive";
+                iconname = "network-transmit-receive-symbolic";
         }
+
+        Logger.info(`Get icon for '${name}': '${iconname}'`);
 
         return new St.Icon({
             icon_name: iconname,
@@ -250,4 +258,15 @@ var NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends 
             this._layouts[i].update_speeds(speeds[i]);
         }
     }
+
+    /**
+     * NetSpeedStatusIcon: update_ips
+     */
+    update_ips(ips) {
+        for (let i = 0; i < ips.length; ++i) {
+            this._layouts[i].update_ips(ips[i]);
+        }
+    }
+
+
 });

--- a/net_speed_status_icon.js
+++ b/net_speed_status_icon.js
@@ -163,8 +163,10 @@ var NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends 
             this._icon.hide();
         // Update Menu sizes
         this._menu_title.update_ui(this._net_speed.menu_label_size);
+        this._menu_title.show_ip(this._net_speed.show_ips);
         for (let layout of this._layouts) {
             layout.update_ui(this._net_speed.menu_label_size);
+            layout.show_ip(this._net_speed.show_ips);
         }
     }
 

--- a/net_speed_status_icon.js
+++ b/net_speed_status_icon.js
@@ -87,6 +87,7 @@ var NetSpeedStatusIcon = GObject.registerClass(class NetSpeedStatusIcon extends 
         this._menu_title.connect("activate", Lang.bind(this, this._change_device, ""));
         this._menu_title.update_speeds({ up: _("Up"), down: _("Down") });
         this._menu_title.update_ips([_("IP")]);
+        this._menu_title.show_ip(this._net_speed.show_ips);
         this.menu.addMenuItem(this._menu_title);
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         this._layouts = new Array();

--- a/po/ca.po
+++ b/po/ca.po
@@ -6,72 +6,128 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Netspeed Gnome-Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2019-07-28 13:37+0200\n"
+"Last-Translator: Jordi Mas i Hernandez <jmas@softcatala.org>\n"
+"Language-Team: \n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Last-Translator: Jordi Mas i Hernandez <jmas@softcatala.org>\n"
-"Language-Team: \n"
 "X-Generator: Poedit 2.2.1\n"
 
-#: prefs.js:60
-#. N.T.: Es refereix a tots els dispositius
+#: prefs.js:62
 msgid "ALL"
 msgstr "Tots"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr "Passarel·la per defecte"
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "Dispositiu a fer seguiment"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Temporitzador (mil·lisegons)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Dígits"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Mida de l'etiqueta"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "Mida de l'etiqueta de la unitat"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Mida de l'etiqueta del menú"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Mostra la suma (pujada + baixada)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Mostra la icona"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr "Usa múltiples de byte"
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr "Usa prefixos binaris"
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -85,10 +141,9 @@ msgstr "Pujada"
 msgid "Down"
 msgstr "Baixada"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
-msgstr "Usa múltiples de byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
+msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr "Usa prefixos binaris"
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Netspeed Gnome-Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2013-11-13 20:39+0100\n"
 "Last-Translator: Jonatan Zeidler <jonatan_zeidler@gmx.de>\n"
 "Language-Team: GERMAN <jonatan_zeidler@gmx.de>\n"
@@ -18,62 +18,119 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "ALLE"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "Gerät zur Überwachung"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Anzeigeinterval (Millisekunden)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Ziffern"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Anzeigegröße"
 
-#: prefs.js:157
+#: prefs.js:185
 #, fuzzy
 msgid "Unit Label Size"
 msgstr "Menügröße"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Menügröße"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Als Summe anzeigen (Hoch+Runter)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Symbol anzeigen"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -87,10 +144,9 @@ msgstr "Hoch"
 msgid "Down"
 msgstr "Runter"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2014-05-25 19:36-0700\n"
 "Last-Translator: Amir Hedayaty <hedayaty@gmail.com>\n"
 "Language-Team: English\n"
@@ -17,62 +17,119 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "ALL"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "Device to monitor"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Timer (milisec)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Digits"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Label Size"
 
-#: prefs.js:157
+#: prefs.js:185
 #, fuzzy
 msgid "Unit Label Size"
 msgstr "Menu Label Size"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Menu Label Size"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Show sum(UP+Down)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Show the Icon"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -86,10 +143,9 @@ msgstr "Up"
 msgid "Down"
 msgstr "Down"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Netspeed Gnome-Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2016-10-12 20:53+0200\n"
 "Last-Translator: Javier Junquera <javier.junquera.sanchez@gmail.com>\n"
 "Language-Team: Español; Castellano <>\n"
@@ -19,61 +19,118 @@ msgstr ""
 "X-Generator: Gtranslator 2.91.7\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "Todos"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr "Puerta de enlace predeterminadas"
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "Dispositivo a monitorizar"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Temporizados (ms)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Digitos"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Tamaño de etiqueta"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "Tamaño de etiqueta de unidades"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Tamaño de etiqueta de menú"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Mostrar suma (subida+bajada)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Mostrar icono"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -87,10 +144,9 @@ msgstr "Subida"
 msgid "Down"
 msgstr "Bajada"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2014-05-25 19:38-0700\n"
 "Last-Translator: Amir Hedayaty <hedayaty@gmail.com>\n"
 "Language-Team: Persian\n"
@@ -16,61 +16,118 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "همه"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "تجهیزات تحت نظارت"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "زمان‌سنج)بر حسب میلی‌ثانیه("
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "تعداد رقم‌ها"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "اندازه برچسب‌ها"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "اندازه واحدها در منو"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "اندازه برچسب‌ها در منو"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "نمایش مجموع)دریافت و ارسال("
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "نمایش نمایه"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -84,10 +141,9 @@ msgstr "ارسال"
 msgid "Down"
 msgstr "دریافت"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2014-05-25 19:36-0700\n"
 "Last-Translator: Lucien Aubert <lu.aubert84@gmail.com>\n"
 "Language-Team: French\n"
@@ -17,62 +17,119 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "TOUS"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "Périphérique(s) à prendre en compte"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Rafraîchissement (milisecondes)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Chiffres"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Taille des champs"
 
-#: prefs.js:157
+#: prefs.js:185
 #, fuzzy
 msgid "Unit Label Size"
 msgstr "Taille des champs du menu"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Taille des champs du menu"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Afficher la somme (reçu+envoyé)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Afficher l'icône"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -86,10 +143,9 @@ msgstr "Envoyé"
 msgid "Down"
 msgstr "Reçu"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2017-04-17 15:58+0200\n"
 "Last-Translator: l3nn4rt <l3nn4rt@protonmail.com>\n"
 "Language-Team: Italian\n"
@@ -18,61 +18,118 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.1\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "Tutte"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr "Gateway di default"
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "Interfaccia da monitorare"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Frequenza di aggiornamento (ms)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Numero di cifre da mostrare"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Larghezza per le cifre"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "Larghezza per le unità di misura"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Larghezza per le colonne del menu"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Mostra la velocità complessiva (upload + download)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Mostra l'icona"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr "Usa multipli del byte"
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr "Usa prefissi binari"
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr "Mostra indirizzi IP"
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -86,10 +143,9 @@ msgstr "Upload"
 msgid "Down"
 msgstr "Download"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
-msgstr "Usa multipli del byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
+msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr "Usa prefissi binari"
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/netspeed.pot
+++ b/po/netspeed.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,60 +17,116 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr ""
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr ""
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr ""
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr ""
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr ""
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr ""
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr ""
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr ""
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr ""
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr ""
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr ""
 
-#: net_speed.js:122
-msgid "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
 msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+msgid "b/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
 msgstr ""
 
 #: net_speed_status_icon.js:86
@@ -85,10 +141,6 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: prefs.js:199
-msgid "Use multiples of byte"
-msgstr ""
-
-#: prefs.js:200
-msgid "Use binary prefixes"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""

--- a/po/nl_NL.po
+++ b/po/nl_NL.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2017-10-26 11:33+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <vistausss@outlook.com>\n"
@@ -18,61 +18,118 @@ msgstr ""
 "X-Generator: Poedit 2.0.4\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "ALLES"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr "Standaard toegangspoort"
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "Te monitoren apparaat"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Timer (milisec.)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Getallen"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Labelgrootte"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "Labelgrootte eenheid"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Labelgrootte menu"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Sum weergeven (OMHOOG+omlaag)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Pictogram weergeven"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -86,10 +143,9 @@ msgstr "Omhoog"
 msgid "Down"
 msgstr "Omlaag"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2016-02-04 17:44-0300\n"
 "Last-Translator: Fábio Nogueira <fnogueira@gnome.org>\n"
 "Language-Team: \n"
@@ -18,61 +18,118 @@ msgstr ""
 "X-Generator: Poedit 1.8.6\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "TUDO"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr "Gateway padrão"
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "Dispositivo para monitorar"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Temporizador (miliseg)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Dígitos"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Tamanho do rótulo"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "Tamanho do rótulo de unidade"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Tamanho do rótulo do menu"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Exibir somatório (UP+Down)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Exibir o ícone"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -86,10 +143,9 @@ msgstr "Up"
 msgid "Down"
 msgstr "Down"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2019-04-23 11:19+0500\n"
 "Last-Translator: Руслан Нигматьянов <ruslan@nigmatyanov.ru>\n"
 "Language-Team: Russian\n"
@@ -18,61 +18,118 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "X-Generator: Gtranslator 3.32.0\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "Все"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr "Шлюз по умолчанию"
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "Интерфейс отображения"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Интервал обновления (милисек)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Цифр"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Длина текста"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "Длина единиц измерения"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Длина заголовка меню"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Показывать общую сумму передачи"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Показывать иконку"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "Б/с"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "КБ/с"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "Б/с"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "МБ/с"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "ГБ/с"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -86,10 +143,9 @@ msgstr "Отправка"
 msgid "Down"
 msgstr "Загрузка"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "КБ/с"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: netspeed\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2019-03-21 09:18+0300\n"
 "Last-Translator: Serdar Sağlam <teknomobil@yandex.com>\n"
 "Language-Team: Türkçe <teknomobil@yandex.com>\n"
@@ -18,61 +18,118 @@ msgstr ""
 "X-Generator: Poedit 2.2.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "Tümü"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr "Öntanımlı Ağ Geçidi"
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "İzlenecek Aygıt"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "Zaman (millisaniye)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "Basamak"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "Etiket Boyutu"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "Birim Etiketi Boyutu"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "Menü Etiket Boyutu"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "Toplamı Göster (Yükleme+İndirme)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "Simgeyi Göster"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -86,10 +143,9 @@ msgstr "Yükleme"
 msgid "Down"
 msgstr "İndirme"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2016-02-20 20:55+0800\n"
 "Last-Translator: Dingzhong Chen <wsxy162@gmail.com>\n"
 "Language-Team: \n"
@@ -18,61 +18,118 @@ msgstr ""
 "X-Generator: Poedit 1.8.7\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "全部"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr "默认网关"
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "监控的设备"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "定时(毫秒)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "位数"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "标签大小"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "单位标签大小"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "菜单标签大小"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "显示总和(上传+下载)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "显示图标"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -86,10 +143,9 @@ msgstr "上传"
 msgid "Down"
 msgstr "下载"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-30 00:30-0700\n"
+"POT-Creation-Date: 2020-03-22 23:26+0100\n"
 "PO-Revision-Date: 2016-02-20 20:55+0800\n"
 "Last-Translator: Dingzhong Chen <wsxy162@gmail.com>\n"
 "Language-Team: \n"
@@ -18,61 +18,118 @@ msgstr ""
 "X-Generator: Poedit 1.8.7\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: prefs.js:60
+#: prefs.js:62
 msgid "ALL"
 msgstr "全部"
 
-#: prefs.js:64
+#: prefs.js:66
 msgid "Default Gateway"
 msgstr "默認網關"
 
-#: prefs.js:153
+#: prefs.js:181
 msgid "Device to monitor"
 msgstr "監控的設備"
 
-#: prefs.js:154
+#: prefs.js:182
 msgid "Timer (milisec)"
 msgstr "定時(毫秒)"
 
-#: prefs.js:155
+#: prefs.js:183
 msgid "Digits"
 msgstr "位數"
 
-#: prefs.js:156
+#: prefs.js:184
 msgid "Label Size"
 msgstr "標籤大小"
 
-#: prefs.js:157
+#: prefs.js:185
 msgid "Unit Label Size"
 msgstr "單位標籤大小"
 
-#: prefs.js:158
+#: prefs.js:186
 msgid "Menu Label Size"
 msgstr "菜單標籤大小"
 
-#: prefs.js:162
+#: prefs.js:187
+msgid "HiDPI factor"
+msgstr ""
+
+#: prefs.js:191
 msgid "Show sum(UP+Down)"
 msgstr "顯示總和(上傳+下載)"
 
-#: prefs.js:163
+#: prefs.js:192
 msgid "Show the Icon"
 msgstr "顯示圖標"
 
-#: net_speed.js:108 net_speed.js:122
+#: prefs.js:235
+msgid "Use multiples of byte"
+msgstr ""
+
+#: prefs.js:236
+msgid "Use binary prefixes"
+msgstr ""
+
+#: prefs.js:245
+msgid "Show IPs"
+msgstr ""
+
+#: net_speed.js:106 net_speed.js:110 net_speed.js:114
 msgid "B/s"
 msgstr "B/s"
 
-#: net_speed.js:122
-msgid "KB/s"
-msgstr "KB/s"
+#: net_speed.js:106
+msgid "kiB/s"
+msgstr ""
 
-#: net_speed.js:122
+#: net_speed.js:106
+msgid "MiB/s"
+msgstr ""
+
+#: net_speed.js:106
+msgid "GiB/s"
+msgstr ""
+
+#: net_speed.js:107 net_speed.js:111
+#, fuzzy
+msgid "b/s"
+msgstr "B/s"
+
+#: net_speed.js:107
+msgid "kib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Mib/s"
+msgstr ""
+
+#: net_speed.js:107
+msgid "Gib/s"
+msgstr ""
+
+#: net_speed.js:110
+msgid "kB/s"
+msgstr ""
+
+#: net_speed.js:110
 msgid "MB/s"
 msgstr "MB/s"
 
-#: net_speed.js:122
+#: net_speed.js:110
 msgid "GB/s"
 msgstr "GB/s"
+
+#: net_speed.js:111
+msgid "kb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Mb/s"
+msgstr ""
+
+#: net_speed.js:111
+msgid "Gb/s"
+msgstr ""
 
 #: net_speed_status_icon.js:86
 msgid "Device"
@@ -86,10 +143,9 @@ msgstr "上傳"
 msgid "Down"
 msgstr "下載"
 
-#: prefs.js:199
-msgid "Use multiples of byte"
+#: net_speed_status_icon.js:89
+msgid "IP"
 msgstr ""
 
-#: prefs.js:200
-msgid "Use binary prefixes"
-msgstr ""
+#~ msgid "KB/s"
+#~ msgstr "KB/s"

--- a/prefs.js
+++ b/prefs.js
@@ -44,7 +44,13 @@ function init()
     let localeDir = Extension.dir.get_child('locale');
     if (localeDir.query_exists(null)) {
         Gettext.bindtextdomain('netspeed', localeDir.get_path());
-	}
+    }
+    
+    if (!Lib.canShowIPs()){
+        // Force to false at startup
+        // FIXME: hide Schema key
+        Schema.set_boolean('show-ips', false);
+    }
 }
 
 const App = class NetSpeed_App {
@@ -237,7 +243,7 @@ const App = class NetSpeed_App {
         });
 
         this.show_ip = new Gtk.CheckButton({ label: _("Show IPs") });
-
+        
         this.main.attach(this.dev, 2, 1, 1, 1);
         this.main.attach(this.sum, 1, 2, 2, 1);
         this.main.attach(this.icon, 1, 3, 2, 1);
@@ -250,10 +256,6 @@ const App = class NetSpeed_App {
         this.main.attach(this.bin_prefixes, 1, 10, 1, 1);
         this.main.attach(this.hi_dpi_factor, 2, 11, 2, 1);
 
-        if (Lib.canShowIPs()) {
-            this.main.attach(this.show_ip, 1, 12, 2, 1);
-        }
-
         Schema.bind('show-sum', this.sum, 'active', Gio.SettingsBindFlags.DEFAULT);
         Schema.bind('icon-display', this.icon, 'active', Gio.SettingsBindFlags.DEFAULT);
         Schema.bind('timer', this.timer, 'value', Gio.SettingsBindFlags.DEFAULT);
@@ -265,6 +267,15 @@ const App = class NetSpeed_App {
         Schema.bind('bin-prefixes', this.bin_prefixes, 'active', Gio.SettingsBindFlags.DEFAULT);
         Schema.bind('hi-dpi-factor', this.hi_dpi_factor, 'value', Gio.SettingsBindFlags.DEFAULT);
         Schema.bind('show-ips', this.show_ip, 'active', Gio.SettingsBindFlags.DEFAULT);
+        Schema.bind_writable('show-ips', this.show_ip, 'visible', false);
+
+        if (Lib.canShowIPs()) {
+            this.main.attach(this.show_ip, 1, 12, 2, 1);
+            this.show_ip.show();
+        } else {
+            this.show_ip.hide();
+        }
+        
 
         this._pick_dev();
         this._factor = Schema.get_int('hi-dpi-factor');

--- a/prefs.js
+++ b/prefs.js
@@ -250,7 +250,7 @@ const App = class NetSpeed_App {
         this.main.attach(this.bin_prefixes, 1, 10, 1, 1);
         this.main.attach(this.hi_dpi_factor, 2, 11, 2, 1);
 
-        if (Lib.showIPs()) {
+        if (Lib.canShowIPs()) {
             this.main.attach(this.show_ip, 1, 12, 2, 1);
         }
 

--- a/schemas/org.gnome.shell.extensions.netspeed.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.netspeed.gschema.xml
@@ -55,5 +55,10 @@
       <summary>Factor for HiDPI screens</summary>
       <description>For normal displays this will be 1. If you want to be able to have bigger labels increase the value for this.</description>
     </key>
+    <key name="show-ips" type="b">
+      <default>false</default>
+      <summary>Use binary prefixes</summary>
+      <description>Set to true to show IPs for each interface</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Hi, I like this extension and thanks your work! I would to contribute to your work.

I make a change to show IP addresses/mask prefix for each interface listed in panel.
I add a check-box to allow show/hide of addresses column.
Below a screenshot of the result.

![Screenshot from 2020-03-23 00-06-08](https://user-images.githubusercontent.com/616846/77264428-9a6fc100-6c9a-11ea-8364-4abea2820243.png)

We can discuss on implementation and how to make it better if you're interested in this feature.
In code comments I insert reminders, explanations or opened issues in external libraries.

Regards