### PR TITLE
Show WiFi SSID for wifi interfaces

### DIFF
--- a/net_speed_layout_menu_item.js
+++ b/net_speed_layout_menu_item.js
@@ -38,6 +38,7 @@ var NetSpeedLayoutMenuItem = GObject.registerClass(
                     , style_class: "ns-menuitem"
                 }
             );
+            this._device_title.get_clutter_text().set_line_wrap(true);
 
             this._down_label = new St.Label({ text: "", style_class: "ns-menuitem" });
             this._up_label = new St.Label({ text: "", style_class: "ns-menuitem" });


### PR DESCRIPTION
Implements #119 

I prefer to leave device interface name (like _wlo1_ mentioned in issue).

![image](https://user-images.githubusercontent.com/616846/133165917-77d7cf29-9738-4c28-bf36-1e7328e7d3c0.png)
