### PR TITLE
Enable "Show IPs" option for GNOME version >= 40

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -151,7 +151,7 @@ function canShowIPs() {
 
     let version_array = splitVersion(Config.PACKAGE_VERSION);
 
-    if (version_array[0] == 3 && (version_array[1] < 28 || version_array[1] >= 34)) {
+    if (version_array[0] >= 40 || (version_array[0] == 3 && (version_array[1] < 28 || version_array[1] >= 34))) {
         getLogger().debug(`Show IP can be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
         return true;
     }

--- a/lib.js
+++ b/lib.js
@@ -152,7 +152,7 @@ function canShowIPs() {
     let version_array = splitVersion(Config.PACKAGE_VERSION);
 
     if (version_array[0] >= 40 || (version_array[0] == 3 && (version_array[1] < 28 || version_array[1] >= 34))) {
-        getLogger().debug(`Show IP can be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);
+        getLogger().debug(`Show IP can be enabled. Gjs version: '${Config.PACKAGE_VERSION}' - Parsed: ${version_array[0]}.${version_array[1]} - Compared: ${version_array[0] >= 40}`);
         return true;
     }
     getLogger().warning(`Show IP cannot be enabled. Gjs version: '${Config.PACKAGE_VERSION}'`);

--- a/net_speed.js
+++ b/net_speed.js
@@ -302,8 +302,14 @@ var NetSpeed = class NetSpeed {
         this.menu_label_size = this._setting.get_int('menu-label-size');
         this.use_bytes = this._setting.get_boolean('use-bytes');
         this.bin_prefixes = this._setting.get_boolean('bin-prefixes');
-        this.show_ips = this._setting.get_boolean('show-ips');
         this.vert_align = this._setting.get_boolean('vert-align');
+
+        let show_ips = this._setting.get_boolean('show-ips');
+        if (show_ips !== this.show_ips && show_ips) {
+            // trigger ip reload
+            this._trigger_ips_reload();
+        }
+        this.show_ips = show_ips;
     }
 
     /**
@@ -364,6 +370,8 @@ var NetSpeed = class NetSpeed {
         let schema = schemaSource.lookup('org.gnome.shell.extensions.netspeed', false);
         this._setting = new Gio.Settings({ settings_schema: schema });
         this._saving = 0;
+        this.show_ips = this._setting.get_boolean('show-ips');
+
         this._load();
 
         this._updateDefaultGw();


### PR DESCRIPTION
Fix to enable `Show IPs` checkbox in settings for GNOME version >= 40.