### PR TITLE
fix: compile issue caused by the incorrect language folder name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE=netspeed
 GETTEXT_PACKAGE = $(PACKAGE)
 UUID = netspeed@hedayaty.gmail.com
 
-LANGUAGES=ca de en_CA fa fr it pt_BR ru zh_CN zh_TW es_ES nl_NL ru tr zh_CN
+LANGUAGES=ca de en_CA fa fr it pt_BR ru zh_CN zh_TW es_ES nl ru tr zh_CN
 DOC_FILES=CHANGELOG README.md
 SRC_FILES=extension.js prefs.js net_speed_layout_menu_item.js net_speed.js net_speed_status_icon.js lib.js
 MO_FILES=$(foreach LANGUAGE, $(LANGUAGES), locale/$(LANGUAGE)/LC_MESSAGES/$(GETTEXT_PACKAGE).mo)


### PR DESCRIPTION
When I compile the latest version, I got

```
make: *** No rule to make target 'locale/nl_NL/LC_MESSAGES/netspeed.mo', needed by 'pack'.  Stop
```

I found a [commit](https://github.com/hedayaty/NetSpeed/pull/136) that changes the nl_NL.po to nl.po 

