### PR TITLE
Add support for GNOME 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,8 @@
   "description": "Displays Internet Speed",
   "name": "NetSpeed",
   "original-author": "hedayaty@gmail.com",
-  "shell-version": [ "40", "41", "42" ],
+  "shell-version": [ "40", "41", "42" , "43" ],
   "url": "https://github.com/hedayaty/NetSpeed",
   "uuid": "netspeed@hedayaty.gmail.com",
-  "version": 32
+  "version": 33
 }


### PR DESCRIPTION
Tested in Arch Linux with Gnome 43
```shell
$ gnome-shell --version
GNOME Shell 43.0
```
![image](https://user-images.githubusercontent.com/19362717/199476746-932154a5-10de-496b-ade0-9ebc256517a8.png)
