### PR TITLE
fix typo in prefs "defaultGW" const

### DIFF
--- a/net_speed.js
+++ b/net_speed.js
@@ -365,12 +365,14 @@ var NetSpeed = class NetSpeed {
         this._saving = 0;
         this._load();
 
+        this._updateDefaultGw();
+
         this._changed = this._setting.connect('changed', Lang.bind(this, this._reload));
         this._timerid = Mainloop.timeout_add(this.timer, Lang.bind(this, this._update));
         this._status_icon = new NetSpeedStatusIcon.NetSpeedStatusIcon(this);
         let placement = this._setting.get_string('placement');
         Panel.addToStatusArea('netspeed', this._status_icon, 0, placement);
-        this._updateDefaultGw();
+
 
     }
 

--- a/prefs.js
+++ b/prefs.js
@@ -164,7 +164,7 @@ const App = class NetSpeed_App {
         let active = 0;
         if (activeDev == "all") {
             active = 0;
-        } else if (activeDev == "defaultGw") {
+        } else if (activeDev == "defaultGW") {
             active = 1;
         } else {
             for (let i = 0; i < this._devices.length; ++i) {


### PR DESCRIPTION
fix typo in prefs `"defaultGW"` const and call `NetSpeed._updateDefaultGw` before creating `NetSpeedStatusIcon`.


Fix #84, #106 ?